### PR TITLE
Enabling unzip of download from Pivnet & Initial README

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,8 @@ MAINTAINER dbaskette@pivotal.io
 #COPY ./configs/* /tmp/
 COPY * /tmp/
 RUN echo root:pivotal | chpasswd \
-	&& yum install -y which tar more util-linux-ng passwd openssh-clients openssh-server ed m4; yum clean all \
+	&& yum install -y unzip which tar more util-linux-ng passwd openssh-clients openssh-server ed m4; yum clean all \
+	&& unzip /tmp/greenplum-db-4.3.7.1-build-1-RHEL5-x86_64.zip -d /tmp/ \
 	&& sed -i s/"more << EOF"/"cat << EOF"/g /tmp/greenplum-db-4.3.7.1-build-1-RHEL5-x86_64.bin \
 	&& echo -e "yes\n\nyes\nyes\n" | /tmp/greenplum-db-4.3.7.1-build-1-RHEL5-x86_64.bin \
 	&& rm /tmp/greenplum-db-4.3.7.1-build-1-RHEL5-x86_64.bin \

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # gpdb-docker
-Greenplum Database Docker image
+Greenplum Database Base Docker image
 
 # Building the Docker Image
 cd [docker working directory]

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@ Greenplum Database Docker image
 
 # Building the Image
 cd [docker working directory]
+
 docker build -t [tag] .
 
 # Running the Image

--- a/README.md
+++ b/README.md
@@ -16,8 +16,6 @@ root/pivotal
 
 gpadmin/pivotal
 
-gpmon/pivotal
-
 # Using psql in the Container
 su - gpadmin
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,13 @@ cd [docker working directory]
 
 docker build -t [tag] .
 
+# Container Accounts
+root/pivotal
+
+gpadmin/pivotal
+
+gpmon/pivotal
+
 # Running the Docker Image
 docker run -i -p 5432:5432 [tag]
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # gpdb-docker
-Pivotal Greenplum Database Base Docker image
+Pivotal Greenplum Database Base Docker Image
 
 # Building the Docker Image
 cd [docker working directory]

--- a/README.md
+++ b/README.md
@@ -4,12 +4,12 @@ Pivotal Greenplum Database Base Docker Image (4.3.7.1)
 # Building the Docker Image
 You will first need to download the Pivotal Greenplum Database 4.3.7.1 installer (.zip) located at https://network.pivotal.io/products/pivotal-gpdb and place it inside the docker working directory.
 
-# Running the Docker Image
-docker run -i -p 5432:5432 [tag]
-
 cd [docker working directory]
 
 docker build -t [tag] .
+
+# Running the Docker Image
+docker run -i -p 5432:5432 [tag]
 
 # Container Accounts
 root/pivotal

--- a/README.md
+++ b/README.md
@@ -4,3 +4,6 @@ Greenplum Database Docker image
 # Building the Image
 cd <docker working directory>
 docker build -t <tag> .
+
+# Running the Image
+docker run -i -p 5432:5432 <tage>

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # gpdb-docker
 Greenplum Database Docker image
 
-# Building the Image
+# Building the Docker Image
 cd [docker working directory]
 
 docker build -t [tag] .
 
-# Running the Image
+# Running the Docker Image
 docker run -i -p 5432:5432 [tag]

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 Pivotal Greenplum Database Base Docker Image (4.3.7.1)
 
 # Building the Docker Image
-You will first need to download the Pivotal Greenplum Database 4.3.7.1 installer (.zip) located at https://network.pivotal.io/products/pivotal-gpdb
+You will first need to download the Pivotal Greenplum Database 4.3.7.1 installer (.zip) located at https://network.pivotal.io/products/pivotal-gpdb and place it inside the docker working directory.
 
 cd [docker working directory]
 

--- a/README.md
+++ b/README.md
@@ -8,3 +8,13 @@ docker build -t [tag] .
 
 # Running the Docker Image
 docker run -i -p 5432:5432 [tag]
+
+# Using psql in the Container
+su - gpadmin
+
+psql
+
+# Using pgadmin outside the Container
+Launch pgAdmin3
+
+Create new connection using IP Address and Port # (5432)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # gpdb-docker
-Pivotal Greenplum Database Base Docker Image
+Pivotal Greenplum Database Base Docker Image (4.3.7.1)
 
 # Building the Docker Image
 cd [docker working directory]

--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@ Pivotal Greenplum Database Base Docker Image (4.3.7.1)
 # Building the Docker Image
 You will first need to download the Pivotal Greenplum Database 4.3.7.1 installer (.zip) located at https://network.pivotal.io/products/pivotal-gpdb and place it inside the docker working directory.
 
+# Running the Docker Image
+docker run -i -p 5432:5432 [tag]
+
 cd [docker working directory]
 
 docker build -t [tag] .
@@ -14,9 +17,6 @@ root/pivotal
 gpadmin/pivotal
 
 gpmon/pivotal
-
-# Running the Docker Image
-docker run -i -p 5432:5432 [tag]
 
 # Using psql in the Container
 su - gpadmin

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Greenplum Database Docker image
 
 # Building the Image
 cd <docker working directory>
-docker build -t <tag> .
+docker build -t [image_tag] .
 
 # Running the Image
-docker run -i -p 5432:5432 <tage>
+docker run -i -p 5432:5432 [image_tag]

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 Pivotal Greenplum Database Base Docker Image (4.3.7.1)
 
 # Building the Docker Image
+You will first need to download the Pivotal Greenplum Database 4.3.7.1 installer (.zip) located at https://network.pivotal.io/products/pivotal-gpdb
+
 cd [docker working directory]
 
 docker build -t [tag] .

--- a/README.md
+++ b/README.md
@@ -1,0 +1,6 @@
+# gpdb-docker
+Greenplum Database Docker image
+
+# Building the Image
+cd <docker working directory>
+docker build -t <tag> .

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # gpdb-docker
-Greenplum Database Base Docker image
+Pivotal Greenplum Database Base Docker image
 
 # Building the Docker Image
 cd [docker working directory]

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Greenplum Database Docker image
 
 # Building the Image
 cd <docker working directory>
-docker build -t [image_tag] .
+docker build -t [tag] .
 
 # Running the Image
-docker run -i -p 5432:5432 [image_tag]
+docker run -i -p 5432:5432 [tag]

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 Greenplum Database Docker image
 
 # Building the Image
-cd <docker working directory>
+cd [docker working directory]
 docker build -t [tag] .
 
 # Running the Image


### PR DESCRIPTION
Two changes to base GPDB Image repo:

1) updated the dockerfile to install the unzip command and use it to unzip the .zip file users will D/L from PivNet. 

2) initiated the readme for the repo - more still needs to go into this such as downloading the zip file from PivNet.